### PR TITLE
Rendering & formatting fixes, closes issue #88

### DIFF
--- a/ct_gen/data/css/selections-img.css
+++ b/ct_gen/data/css/selections-img.css
@@ -3,7 +3,7 @@
 /* Body */
 body {
   font-family: 'Nunito Sans', sans-serif;
-  font-size: 30px;
+  font-size: 16px;
   line-height: 1.6;
   color: #333333;
 }
@@ -11,7 +11,6 @@ body {
 /* Heading */
 h1, h2, h3, h4, h5, h6 {
   font-weight: 700;
-  line-height: 1.3;
 }
 
 /* Links */
@@ -22,10 +21,4 @@ a {
 
 a:hover {
   text-decoration: underline;
-}
-
-p{
-  font-size: 21px; /* Same as body font size */
-  line-height: 1.6;
-  text-align: justify; /* Justify text in paragraphs */
 }

--- a/ct_gen/src/modules/markdown_functions.py
+++ b/ct_gen/src/modules/markdown_functions.py
@@ -2,11 +2,11 @@ import markdown2
 import imgkit
 from io import BytesIO
 
-def markdown_to_image(markdown_text):
+def markdown_to_image(markdown_text, css_path):
     # Convert Markdown to HTML
     html_content = markdown2.markdown(markdown_text)
     
     # Convert HTML to an image
-    imgkit_options = {'format': 'png'}
-    img_bytes = imgkit.from_string(html_content,False, options= imgkit_options, css= "ct_gen/data/css/CT-img.css")
+    imgkit_options = {'format': 'jpg'}
+    img_bytes = imgkit.from_string(html_content,False, options= imgkit_options, css= css_path)
     return img_bytes

--- a/ct_gen/src/pages/page_5.py
+++ b/ct_gen/src/pages/page_5.py
@@ -28,7 +28,7 @@ def selections_merger(images_list, captions_list):
         content = content + new_img
     content = content + "</tr></table>"
     
-    return markdown_to_image(content)
+    return markdown_to_image(content, "ct_gen/data/css/selections-img.css")
 
 
 def create_prompt():
@@ -82,8 +82,8 @@ def generate_conspiracy_theory(prompt, _client):
         if chunk.choices[0].delta.content is not None:
             report.append(chunk.choices[0].delta.content)
             result = "".join(report).strip()
-            res_box.markdown(f'{result}') 
-    disclaimer = "<br>Warning: This conspiracy story is FAKE and was generated with the Conspiracy Generator, an educational tool."
+            res_box.write(result, unsafe_allow_html=True) 
+    disclaimer = "<br><p>**Warning: This conspiracy story is FAKE and was generated with the Conspiracy Generator, an educational tool.**</p>"
     report.append(disclaimer)
     st.session_state["conspiracy_theory"] = "".join(report).strip()
 
@@ -187,7 +187,7 @@ def display_page_5():
         
 
    # Convert Markdown to an image
-    image_bytes = markdown_to_image(st.session_state["conspiracy_theory"])
+    image_bytes = markdown_to_image(st.session_state["conspiracy_theory"], "ct_gen/data/css/CT-img.css")
 
     # Display the image in Streamlit
     st.image(image_bytes, caption='Generated Conspiracy Theory', use_column_width=True)
@@ -196,10 +196,10 @@ def display_page_5():
     st.markdown(f"<h3 style='text-align: center;'><b>Download images & Share</b></h3>", unsafe_allow_html=True)
     col1,col2 = st.columns(2)
     with col1:
-        st.download_button('Download Selections', data=selections_merger(images_list, captions_list), file_name='CT Selections.png')
+        st.download_button('Download Selections', data=selections_merger(images_list, captions_list), file_name='CT Selections.jpg')
 
     with col2:
-        st.download_button('Download Conspiracy Theory', data=image_bytes, file_name='Conspiracy Theory.png')
+        st.download_button('Download Conspiracy Theory', data=image_bytes, file_name='Conspiracy Theory.jpg')
     
     create_twitter_button(image_bytes)
     st.markdown(f"<h3 style='text-align: center;'><b>Rate us!</b></h3>", unsafe_allow_html=True)    


### PR DESCRIPTION
Closes issue #88 by:
- Inconsistent rendering of Markdown in the generate_conspiracy_theory() method fixed.
- Added "selections-img.css" for formatting text in the Selections image.
- Changed output format for generated images using markdown_to_image() to "jpg" instead of "png" to reduce size.
